### PR TITLE
Fix case insensitive import of FritzBoxAPI.js

### DIFF
--- a/libs/ItemFactory.js
+++ b/libs/ItemFactory.js
@@ -2,7 +2,7 @@
 var exports = module.exports = {};
 exports.AbstractItem = require('../items/AbstractItem.js');
 exports.WifiGuestItem = require('../items/WifiGuestItem.js');
-var FritzBoxAPI = require('./FritzBoxApi.js').FritzBoxAPI;
+var FritzBoxAPI = require('./FritzBoxAPI.js').FritzBoxAPI;
 
 exports.Factory = function(FRITZBoxPlatform,homebridge) {
     this.platform = FRITZBoxPlatform;


### PR DESCRIPTION
On case sensitive filesystems (e.g. when running on a Raspberry Pi), the `require` failed since the file is called `FritzBoxAPI.js` instead of `FritzBoxApi.js`.
